### PR TITLE
Ensure deploy recreates running containers

### DIFF
--- a/.github/workflows/deploy-agora.yml
+++ b/.github/workflows/deploy-agora.yml
@@ -68,6 +68,8 @@ jobs:
 
           git fetch --prune origin "$TARGET_REF"
           git checkout -B "$TARGET_REF" FETCH_HEAD
+          echo "Deploying commit $(git rev-parse --short HEAD) on $(hostname)"
 
-          docker compose up -d --build --remove-orphans
+          docker compose up -d --build --force-recreate --remove-orphans
+          docker compose ps
           EOF


### PR DESCRIPTION
## Summary
- add `--force-recreate` to the deploy `docker compose up` command
- print deployed commit hash and `docker compose ps` in workflow logs

## Why
Recent merges built a new image but left the running API container unchanged, so older code stayed live despite successful workflow runs. This makes deploy behavior deterministic.
