### PR TITLE
Refactor /register into agent handoff workflow

### DIFF
--- a/agora/main.py
+++ b/agora/main.py
@@ -3,7 +3,6 @@
 import asyncio
 import hmac
 import ipaddress
-import json
 import logging
 from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
@@ -440,70 +439,15 @@ async def agent_detail_page(
 
 @app.get("/register", response_class=HTMLResponse, include_in_schema=False)
 async def register_page(request: Request) -> HTMLResponse:
+    registry_base_url = str(request.base_url).rstrip("/")
     return templates.TemplateResponse(
         "register.html",
         {
             "request": request,
-            "agent_card_json": "",
-            "api_key_value": "",
-            "error_message": None,
-            "success_result": None,
+            "registry_base_url": registry_base_url,
+            "register_endpoint": f"{registry_base_url}/api/v1/agents",
+            "health_endpoint": f"{registry_base_url}/api/v1/health",
         },
-    )
-
-
-@app.post("/register", response_class=HTMLResponse, include_in_schema=False)
-async def register_submit_page(
-    request: Request,
-    session: AsyncSession = Depends(get_db_session),
-    agent_card_json: str = Form(...),
-    api_key: str = Form(...),
-) -> HTMLResponse:
-    try:
-        payload = json.loads(agent_card_json)
-    except json.JSONDecodeError as exc:
-        return templates.TemplateResponse(
-            "register.html",
-            {
-                "request": request,
-                "agent_card_json": agent_card_json,
-                "api_key_value": api_key,
-                "error_message": f"Invalid JSON: {exc}",
-                "success_result": None,
-            },
-            status_code=400,
-        )
-
-    try:
-        result = await register_agent(
-            agent_card_payload=payload,
-            request=request,
-            session=session,
-            api_key=api_key,
-        )
-    except HTTPException as exc:
-        return templates.TemplateResponse(
-            "register.html",
-            {
-                "request": request,
-                "agent_card_json": agent_card_json,
-                "api_key_value": api_key,
-                "error_message": exc.detail,
-                "success_result": None,
-            },
-            status_code=exc.status_code,
-        )
-
-    return templates.TemplateResponse(
-        "register.html",
-        {
-            "request": request,
-            "agent_card_json": agent_card_json,
-            "api_key_value": api_key,
-            "error_message": None,
-            "success_result": result,
-        },
-        status_code=201,
     )
 
 

--- a/agora/templates/register.html
+++ b/agora/templates/register.html
@@ -1,211 +1,425 @@
 {% extends "base.html" %}
-{% block title %}Register Agent — Agora{% endblock %}
+{% block title %}Register Agent - Agora{% endblock %}
 
 {% block head %}
 <style>
-  .register-container {
-    max-width: 560px;
+  .handoff-container {
+    max-width: 960px;
     margin: 0 auto;
-  }
-  .form-section {
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
+    gap: 1rem;
+  }
+  .hero {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .hero p {
+    color: var(--ink-secondary);
+    max-width: 70ch;
+  }
+  .security-note {
+    border: 1px solid var(--warning);
+    background: var(--warning-subtle);
+    border-radius: var(--radius-sm);
+    color: var(--warning);
+    padding: 0.75rem 0.875rem;
+    font-size: 0.875rem;
+  }
+  .info-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+  .callout {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    background: var(--bg);
+  }
+  .callout code {
+    display: block;
+    margin-top: 0.375rem;
+    font-size: 0.8125rem;
+    word-break: break-all;
+  }
+  .endpoint-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+  }
+  .form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.875rem;
+  }
+  .full-width {
+    grid-column: 1 / -1;
   }
   .form-group {
     display: flex;
     flex-direction: column;
     gap: 0.375rem;
   }
+  .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
   .form-hint {
     font-size: 0.8125rem;
     color: var(--ink-tertiary);
   }
-  .success-card {
-    text-align: center;
-    padding: 2rem;
+  .output-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
   }
-  .success-icon {
-    width: 64px;
-    height: 64px;
-    background: var(--success-subtle);
-    border-radius: 50%;
+  .textarea {
+    min-height: 260px;
+    resize: vertical;
+    font-size: 0.8125rem;
+    line-height: 1.45;
+  }
+  .button-row {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0 auto 1rem;
+    flex-wrap: wrap;
+    gap: 0.625rem;
+    margin-top: 0.625rem;
   }
-  .key-display {
-    background: #1e1e1e;
-    color: #4ade80;
-    padding: 1rem;
-    border-radius: var(--radius-sm);
-    font-family: "JetBrains Mono", monospace;
+  .status-message {
     font-size: 0.875rem;
-    margin: 1rem 0;
-    word-break: break-all;
-    position: relative;
-  }
-  .key-warning {
-    background: var(--warning-subtle);
-    border: 1px solid var(--warning);
-    border-radius: var(--radius-sm);
-    padding: 0.75rem 1rem;
-    color: var(--warning);
-    font-size: 0.875rem;
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5rem;
+    color: var(--ink-secondary);
+    min-height: 1.25rem;
   }
   .error-message {
-    background: var(--danger-subtle);
     border: 1px solid var(--danger);
+    background: var(--danger-subtle);
     border-radius: var(--radius-sm);
-    padding: 0.75rem 1rem;
+    padding: 0.625rem 0.75rem;
     color: var(--danger);
     font-size: 0.875rem;
   }
-  .textarea {
-    min-height: 100px;
-    resize: vertical;
+  @media (max-width: 820px) {
+    .info-grid,
+    .form-grid,
+    .output-grid {
+      grid-template-columns: 1fr;
+    }
   }
 </style>
 {% endblock %}
 
 {% block content %}
-<div class="register-container flex flex-col gap-6">
+<div
+  id="registry-meta"
+  data-base-url="{{ registry_base_url }}"
+  data-register-endpoint="{{ register_endpoint }}"
+  data-health-endpoint="{{ health_endpoint }}"
+  class="handoff-container"
+>
+  <section class="card hero">
+    <h1>Give Registration to Your Agent</h1>
+    <p>
+      Instead of registering manually, create an agent handoff packet here and give it to your coding
+      agent. It can fetch your <span class="mono">SKILL.md</span>, build an Agent Card, and call the
+      registry API directly.
+    </p>
+    <div class="security-note">
+      Keep your owner API key private. This page does not submit it to the server; packet generation
+      runs in your browser.
+    </div>
+  </section>
 
-  {% if success_result %}
-    <!-- Success state -->
-    <div class="card success-card">
-      <div class="success-icon">
-        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2">
-          <path d="M20 6L9 17l-5-5"/>
-        </svg>
+  <section class="card info-grid">
+    <div class="endpoint-list">
+      <h2>Registry Details</h2>
+      <div class="callout">
+        Base URL
+        <code id="registry-base-url">{{ registry_base_url }}</code>
       </div>
-      <h1 style="font-size: 1.5rem;">{{ success_result.name }} is live!</h1>
-      <p class="text-secondary mt-2">Your agent is now discoverable in the registry.</p>
-      
-      <div class="key-warning mt-6">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink: 0;">
-          <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
-          <line x1="12" y1="9" x2="12" y2="13"/>
-          <line x1="12" y1="17" x2="12.01" y2="17"/>
-        </svg>
-        <span>Save your API key now. You won't be able to see it again.</span>
+      <div class="callout">
+        Health endpoint
+        <code>{{ health_endpoint }}</code>
       </div>
-      
-      <div class="key-display">
-        <span id="api-key">{{ api_key_value }}</span>
+      <div class="callout">
+        Register endpoint
+        <code>{{ register_endpoint }}</code>
       </div>
-      
-      <button class="btn btn-primary" onclick="copyKey()" id="copy-btn" style="width: 100%;">
-        Copy API Key
-      </button>
-      
-      <div class="flex gap-3 mt-6 justify-center">
-        <a href="/agent/{{ success_result.id }}" class="btn btn-secondary">View agent profile</a>
-        <a href="/register" class="btn btn-ghost">Register another</a>
+      <div class="callout">
+        Auth header
+        <code>X-API-Key: &lt;owner-api-key&gt;</code>
       </div>
     </div>
 
-  {% else %}
-    <!-- Registration form -->
-    <div class="flex flex-col gap-2">
-      <h1>Register an Agent</h1>
-      <p class="text-secondary">
-        Add your A2A-compatible agent to the public registry. You'll receive an API key for future updates.
-      </p>
-    </div>
+    <form id="handoff-builder" class="form-grid" autocomplete="off">
+      <h2 class="full-width">Handoff Packet Inputs</h2>
 
-    {% if error_message %}
-      <div class="error-message">{{ error_message }}</div>
-    {% endif %}
-
-    <form action="/register" method="post" class="card form-section">
-      <div class="form-group">
-        <label class="label" for="api_key">Owner API key</label>
+      <div class="form-group full-width">
+        <label class="label" for="owner_api_key">Owner API key</label>
         <input
+          id="owner_api_key"
+          name="owner_api_key"
           type="password"
-          id="api_key"
-          name="api_key"
           class="input mono"
-          placeholder="your-owner-api-key"
-          value="{{ api_key_value or '' }}"
+          placeholder="owner-api-key"
           required
         >
-        <span class="form-hint">Keep this key safe. You'll use it to update or delete this agent.</span>
+        <span class="form-hint">
+          The same key your agent should send in <span class="mono">X-API-Key</span>.
+        </span>
       </div>
-      
+
+      <div class="form-group full-width">
+        <label class="label" for="skill_md_url">Your SKILL.md URL</label>
+        <input
+          id="skill_md_url"
+          name="skill_md_url"
+          type="url"
+          class="input mono"
+          placeholder="https://example.com/SKILL.md"
+          required
+        >
+        <span class="form-hint">Where your coding agent can fetch implementation instructions.</span>
+      </div>
+
       <div class="form-group">
-        <label class="label" for="name">Agent name</label>
-        <input 
-          type="text" 
-          id="name" 
-          name="name" 
-          class="input" 
-          placeholder="My Agent"
-          value=""
+        <label class="label" for="agent_name">Agent name</label>
+        <input id="agent_name" name="agent_name" type="text" class="input" value="My Agent" required>
+      </div>
+      <div class="form-group">
+        <label class="label" for="agent_url">Agent URL</label>
+        <input
+          id="agent_url"
+          name="agent_url"
+          type="url"
+          class="input mono"
+          placeholder="https://agent.example.com"
+          required
         >
       </div>
 
       <div class="form-group">
-        <label class="label" for="url">Agent URL</label>
-        <input 
-          type="url" 
-          id="url" 
-          name="url" 
-          class="input mono" 
-          placeholder="https://example.com/agent"
-          value=""
-        >
-        <span class="form-hint">The URL where your agent's A2A endpoint lives</span>
+        <label class="label" for="skill_id">Primary skill id</label>
+        <input id="skill_id" name="skill_id" type="text" class="input mono" value="primary-skill" required>
+      </div>
+      <div class="form-group">
+        <label class="label" for="skill_name">Primary skill name</label>
+        <input id="skill_name" name="skill_name" type="text" class="input" value="Primary Skill" required>
       </div>
 
       <div class="form-group">
-        <label class="label" for="description">Description</label>
-        <textarea 
-          id="description" 
-          name="description" 
-          class="input textarea" 
-          placeholder="What does your agent do?"
+        <label class="label" for="protocol_version">Protocol version</label>
+        <input id="protocol_version" name="protocol_version" type="text" class="input mono" value="0.3.0" required>
+      </div>
+      <div class="form-group">
+        <label class="label" for="agent_version">Agent version</label>
+        <input id="agent_version" name="agent_version" type="text" class="input mono" value="1.0.0" required>
+      </div>
+
+      <div class="form-group full-width">
+        <label class="label" for="agent_description">Agent description</label>
+        <textarea
+          id="agent_description"
+          name="agent_description"
+          class="input"
+          rows="2"
+          placeholder="Describe your agent"
         ></textarea>
       </div>
 
-      <div class="form-group">
-        <label class="label" for="agent_card_json">Agent Card JSON</label>
-        <textarea 
-          id="agent_card_json" 
-          name="agent_card_json" 
-          class="input textarea mono" 
-          placeholder='{"protocolVersion": "0.3.0", "skills": [...]}'
-          style="min-height: 120px;"
-          required
-        >{{ agent_card_json or '' }}</textarea>
-        <span class="form-hint">Provide a full A2A Agent Card JSON payload.</span>
+      <div class="form-group full-width">
+        <label class="label" for="skill_description">Primary skill description</label>
+        <textarea
+          id="skill_description"
+          name="skill_description"
+          class="input"
+          rows="2"
+          placeholder="Describe your primary skill"
+        ></textarea>
       </div>
 
-      <button type="submit" class="btn btn-primary" style="margin-top: 0.5rem;">
-        Register agent
-      </button>
+      <div class="checkbox-row full-width">
+        <input id="supports_streaming" name="supports_streaming" type="checkbox" checked>
+        <label for="supports_streaming">Streaming capability enabled</label>
+      </div>
 
+      <div id="builder-error" class="error-message full-width" hidden></div>
+
+      <div class="button-row full-width">
+        <button type="submit" class="btn btn-primary">Generate handoff packet</button>
+        <button type="button" class="btn btn-secondary" id="copy-packet-btn">Copy packet JSON</button>
+        <button type="button" class="btn btn-secondary" id="copy-prompt-btn">Copy agent prompt</button>
+      </div>
+
+      <div id="builder-status" class="status-message full-width"></div>
     </form>
-  {% endif %}
+  </section>
 
+  <section class="output-grid">
+    <div class="card">
+      <h3>Handoff Packet JSON</h3>
+      <p class="text-secondary text-sm" style="margin: 0.375rem 0 0.75rem;">
+        Share this directly with your agent.
+      </p>
+      <textarea id="handoff_packet" class="input textarea mono" readonly></textarea>
+    </div>
+    <div class="card">
+      <h3>Agent Prompt</h3>
+      <p class="text-secondary text-sm" style="margin: 0.375rem 0 0.75rem;">
+        Optional prompt if your agent works better with plain text instructions.
+      </p>
+      <textarea id="agent_prompt" class="input textarea mono" readonly></textarea>
+    </div>
+  </section>
 </div>
 
 <script>
-function copyKey() {
-  const key = document.getElementById('api-key').textContent;
-  navigator.clipboard.writeText(key).then(() => {
-    const btn = document.getElementById('copy-btn');
-    btn.textContent = '✓ Copied!';
-    btn.style.background = 'var(--success)';
-    setTimeout(() => {
-      btn.textContent = 'Copy API Key';
-      btn.style.background = '';
-    }, 3000);
-  });
+function readValue(id) {
+  const element = document.getElementById(id);
+  if (!element) {
+    return "";
+  }
+  if (element.type === "checkbox") {
+    return element.checked;
+  }
+  return (element.value || "").trim();
 }
+
+function setStatus(message) {
+  document.getElementById("builder-status").textContent = message;
+}
+
+function setError(message) {
+  const error = document.getElementById("builder-error");
+  if (!message) {
+    error.hidden = true;
+    error.textContent = "";
+    return;
+  }
+  error.hidden = false;
+  error.textContent = message;
+}
+
+function buildHandoffPacket() {
+  const meta = document.getElementById("registry-meta");
+  const registryBaseUrl = meta.dataset.baseUrl;
+  const registerEndpoint = meta.dataset.registerEndpoint;
+  const healthEndpoint = meta.dataset.healthEndpoint;
+
+  const ownerApiKey = readValue("owner_api_key");
+  const skillMdUrl = readValue("skill_md_url");
+  const agentName = readValue("agent_name");
+  const agentUrl = readValue("agent_url");
+  const skillId = readValue("skill_id");
+  const skillName = readValue("skill_name");
+  const protocolVersion = readValue("protocol_version");
+  const agentVersion = readValue("agent_version");
+  const agentDescription = readValue("agent_description");
+  const skillDescription = readValue("skill_description");
+  const supportsStreaming = readValue("supports_streaming");
+
+  if (!skillMdUrl || !agentUrl || !ownerApiKey) {
+    throw new Error("Owner API key, SKILL.md URL, and agent URL are required.");
+  }
+
+  const packet = {
+    task: "Fetch SKILL.md and register this agent in Agora",
+    registry: {
+      base_url: registryBaseUrl,
+      health_endpoint: healthEndpoint,
+      register_endpoint: registerEndpoint,
+      auth_header: "X-API-Key",
+      auth_value: ownerApiKey,
+    },
+    skill_md_url: skillMdUrl,
+    agent_card: {
+      protocolVersion: protocolVersion || "0.3.0",
+      name: agentName || "My Agent",
+      description: agentDescription || null,
+      url: agentUrl,
+      version: agentVersion || "1.0.0",
+      capabilities: {
+        streaming: Boolean(supportsStreaming),
+      },
+      skills: [
+        {
+          id: skillId || "primary-skill",
+          name: skillName || "Primary Skill",
+          description: skillDescription || null,
+        },
+      ],
+    },
+    required_fields: ["protocolVersion", "name", "url", "skills"],
+    requested_outputs: [
+      "registration response JSON",
+      "new agent id",
+      "final normalized agent URL",
+    ],
+  };
+
+  const prompt = [
+    "Use this packet to self-register an agent into Agora.",
+    "1. GET the SKILL.md URL and follow its instructions.",
+    "2. Verify registry health before registration.",
+    "3. Build/adjust the agent card if needed, keeping required fields.",
+    "4. POST the card to the register endpoint with the provided X-API-Key.",
+    "5. Return the created agent id and response payload.",
+    "",
+    "Packet:",
+    JSON.stringify(packet, null, 2),
+  ].join("\n");
+
+  return {packet, prompt};
+}
+
+function generatePacket() {
+  setError("");
+  try {
+    const result = buildHandoffPacket();
+    document.getElementById("handoff_packet").value = JSON.stringify(result.packet, null, 2);
+    document.getElementById("agent_prompt").value = result.prompt;
+    setStatus("Packet generated locally in your browser.");
+  } catch (error) {
+    setStatus("");
+    setError(error.message || "Unable to generate packet.");
+  }
+}
+
+async function copyField(fieldId, buttonId, successLabel) {
+  const value = document.getElementById(fieldId).value || "";
+  if (!value) {
+    setError("Generate the packet first so there is something to copy.");
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(value);
+    const button = document.getElementById(buttonId);
+    const previousText = button.textContent;
+    button.textContent = successLabel;
+    setStatus("Copied to clipboard.");
+    setTimeout(() => {
+      button.textContent = previousText;
+    }, 1400);
+  } catch (_error) {
+    setError("Clipboard copy failed. Copy the text manually.");
+  }
+}
+
+document.getElementById("handoff-builder").addEventListener("submit", function(event) {
+  event.preventDefault();
+  generatePacket();
+});
+
+document.getElementById("copy-packet-btn").addEventListener("click", function() {
+  copyField("handoff_packet", "copy-packet-btn", "Copied packet");
+});
+
+document.getElementById("copy-prompt-btn").addEventListener("click", function() {
+  copyField("agent_prompt", "copy-prompt-btn", "Copied prompt");
+});
+
+generatePacket();
 </script>
 {% endblock %}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -75,7 +75,7 @@ Returns stale candidates report if `ADMIN_API_TOKEN` is configured.
 - `GET /` home
 - `GET /search` search UI
 - `GET /agent/{id}` detail UI
-- `GET/POST /register` registration UI flow
+- `GET /register` agent handoff packet UI (for agent-driven registration)
 - `GET/POST /recover` recovery UI flow
 
 ## Status Codes (Common)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -40,7 +40,7 @@ Expected response:
 Open:
 
 - UI home: `http://localhost:8000/`
-- Register form: `http://localhost:8000/register`
+- Register handoff page: `http://localhost:8000/register`
 - Recovery form: `http://localhost:8000/recover`
 - API docs: `http://localhost:8000/docs`
 


### PR DESCRIPTION
## Summary
- replace the human `/register` submission form with an agent-handoff packet builder UI
- keep `/register` as GET-only and expose registry metadata (base URL, health endpoint, register endpoint)
- generate packet JSON + optional prompt in-browser with required registration fields and `X-API-Key` usage
- remove the legacy `/register` POST UI flow
- update docs to reflect the handoff flow

## Testing
- `.venv/bin/pytest tests/integration/test_register_form.py -q`
