### PR TITLE
fix: merge migration for erc8004 + reputation phase1 heads

### DIFF
--- a/alembic/versions/20260308_0008_merge_erc8004_reputation_heads.py
+++ b/alembic/versions/20260308_0008_merge_erc8004_reputation_heads.py
@@ -1,0 +1,24 @@
+"""Merge erc8004_verified and reputation phase1 schema heads
+
+Revision ID: 20260308_0008
+Revises: 20260307_0007, 20260308_0007
+Create Date: 2026-03-08 23:40:00.000000
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20260308_0008"
+down_revision: tuple[str, str] = ("20260307_0007", "20260308_0007")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
**Hotfix — already deployed to production.**

Gavlan's ERC-8004 migration (`20260308_0007`) branched from `20260303_0006` (econ_id) instead of from `20260307_0007` (reputation phase1 schema), creating two heads. This caused `alembic upgrade head` to fail on startup, taking down the-agora.dev.

This merge migration (`20260308_0008`) points to both heads as its `down_revision` tuple, resolving the split with no schema changes.

**This file is already committed and running on the server.** This PR syncs GitHub's main to match. Without this merge, Gavlan's next PR will branch from a main that's missing this migration, causing the same problem on next deploy.

Root cause: Gavlan should always `git pull --rebase origin main` before starting new work, not just before opening the PR.