### PR TITLE
feat: add Ed25519 verificationMethod to DID document

### DIFF
--- a/agora/config.py
+++ b/agora/config.py
@@ -38,6 +38,11 @@ class Settings(BaseSettings):
     admin_rate_limit_global: int = 300
     monthly_budget_cents: int | None = None
 
+    # DID verificationMethod: Ed25519 public key in multibase encoding (z-prefixed base58btc).
+    # When set, the /.well-known/did.json endpoint includes verificationMethod,
+    # authentication, and assertionMethod fields per W3C DID Core + Ed25519 2020 suite.
+    did_public_key_multibase: str | None = None
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/agora/main.py
+++ b/agora/main.py
@@ -941,20 +941,41 @@ async def well_known_agent_card(request: Request) -> JSONResponse:
 
 @app.get("/.well-known/did.json", tags=["meta"], include_in_schema=False)
 async def well_known_did_document() -> JSONResponse:
-    return JSONResponse(
-        {
-            "@context": ["https://www.w3.org/ns/did/v1"],
-            "id": "did:web:the-agora.dev",
-            "service": [
-                {
-                    "id": "did:web:the-agora.dev#registry",
-                    "type": "AgentRegistry",
-                    "serviceEndpoint": "https://the-agora.dev",
-                }
-            ],
-        },
-        media_type="application/did+json",
-    )
+    did = "did:web:the-agora.dev"
+    contexts: list[str] = ["https://www.w3.org/ns/did/v1"]
+    document: dict[str, object] = {
+        "id": did,
+        "service": [
+            {
+                "id": f"{did}#registry",
+                "type": "AgentRegistry",
+                "serviceEndpoint": "https://the-agora.dev",
+            }
+        ],
+    }
+
+    settings = get_settings()
+    pub_key = settings.did_public_key_multibase
+    if pub_key:
+        contexts.append("https://w3id.org/security/suites/ed25519-2020/v1")
+        key_id = f"{did}#key-1"
+        document["verificationMethod"] = [
+            {
+                "id": key_id,
+                "type": "Ed25519VerificationKey2020",
+                "controller": did,
+                "publicKeyMultibase": pub_key,
+            }
+        ]
+        document["authentication"] = [key_id]
+        document["assertionMethod"] = [key_id]
+
+    document["@context"] = contexts
+    # Move @context to the front of the serialized output.
+    ordered: dict[str, object] = {"@context": contexts}
+    ordered.update(document)
+
+    return JSONResponse(ordered, media_type="application/did+json")
 
 
 @app.get("/", response_class=HTMLResponse, include_in_schema=False)

--- a/tests/integration/test_a2a_agent_card.py
+++ b/tests/integration/test_a2a_agent_card.py
@@ -28,7 +28,8 @@ async def test_well_known_did_json_is_available(client) -> None:
     assert response.headers["content-type"].startswith("application/did+json")
 
     payload = response.json()
-    assert payload["@context"] == ["https://www.w3.org/ns/did/v1"]
+    # Base context always present
+    assert "https://www.w3.org/ns/did/v1" in payload["@context"]
     assert payload["id"] == "did:web:the-agora.dev"
     assert payload["service"] == [
         {
@@ -37,6 +38,8 @@ async def test_well_known_did_json_is_available(client) -> None:
             "serviceEndpoint": "https://the-agora.dev",
         }
     ]
+    # @context is the first key
+    assert list(payload.keys())[0] == "@context"
 
 
 async def test_register_agent_supports_agent_card_url(client, monkeypatch) -> None:

--- a/tests/unit/test_well_known_did_document.py
+++ b/tests/unit/test_well_known_did_document.py
@@ -5,7 +5,8 @@ import httpx
 from agora.main import app
 
 
-async def test_well_known_did_json_route() -> None:
+async def test_well_known_did_json_without_key() -> None:
+    """When no public key is configured, serve the base DID document."""
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         response = await client.get("/.well-known/did.json")
@@ -14,14 +15,57 @@ async def test_well_known_did_json_route() -> None:
     assert response.headers["content-type"].startswith("application/did+json")
 
     payload = response.json()
-    assert payload == {
-        "@context": ["https://www.w3.org/ns/did/v1"],
-        "id": "did:web:the-agora.dev",
-        "service": [
-            {
-                "id": "did:web:the-agora.dev#registry",
-                "type": "AgentRegistry",
-                "serviceEndpoint": "https://the-agora.dev",
-            }
-        ],
-    }
+    assert payload["@context"] == ["https://www.w3.org/ns/did/v1"]
+    assert payload["id"] == "did:web:the-agora.dev"
+    assert payload["service"] == [
+        {
+            "id": "did:web:the-agora.dev#registry",
+            "type": "AgentRegistry",
+            "serviceEndpoint": "https://the-agora.dev",
+        }
+    ]
+    # No verificationMethod when key is absent
+    assert "verificationMethod" not in payload
+    assert "authentication" not in payload
+    assert "assertionMethod" not in payload
+
+
+async def test_well_known_did_json_with_verification_method(monkeypatch) -> None:
+    """When a public key is configured, include verificationMethod fields."""
+    test_key = "z6MktestKeyForUnitTestsOnly1234567890abcdefg"
+    monkeypatch.setenv("DID_PUBLIC_KEY_MULTIBASE", test_key)
+
+    # Clear the settings cache so monkeypatched env is picked up
+    from agora.config import get_settings
+    get_settings.cache_clear()
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get("/.well-known/did.json")
+
+        assert response.status_code == 200
+        payload = response.json()
+
+        # Extended context
+        assert "https://w3id.org/security/suites/ed25519-2020/v1" in payload["@context"]
+
+        # verificationMethod present and correct
+        assert len(payload["verificationMethod"]) == 1
+        vm = payload["verificationMethod"][0]
+        assert vm["id"] == "did:web:the-agora.dev#key-1"
+        assert vm["type"] == "Ed25519VerificationKey2020"
+        assert vm["controller"] == "did:web:the-agora.dev"
+        assert vm["publicKeyMultibase"] == test_key
+
+        # authentication and assertionMethod reference the key
+        assert payload["authentication"] == ["did:web:the-agora.dev#key-1"]
+        assert payload["assertionMethod"] == ["did:web:the-agora.dev#key-1"]
+
+        # @context is the first key in the JSON output
+        keys = list(payload.keys())
+        assert keys[0] == "@context"
+    finally:
+        # Restore clean settings cache
+        monkeypatch.delenv("DID_PUBLIC_KEY_MULTIBASE", raising=False)
+        get_settings.cache_clear()


### PR DESCRIPTION
## What

Adds optional Ed25519 verificationMethod to the `/.well-known/did.json` endpoint, aligning with the WG convergence on Ed25519 + did:web from A2A #1667.

## How

- New config setting: `DID_PUBLIC_KEY_MULTIBASE` (env var)
- When set, the DID document includes:
  - `verificationMethod` (Ed25519VerificationKey2020 with publicKeyMultibase)
  - `authentication` array referencing the key
  - `assertionMethod` array referencing the key
  - Extended `@context` with Ed25519 2020 suite
- When unset, serves the existing base document (fully backward compatible)
- No new dependencies — the public key is just a config string

## Format reference

Follows The-Nexus-Guard's reference format from A2A #1667:
```json
{
  "@context": [
    "https://www.w3.org/ns/did/v1",
    "https://w3id.org/security/suites/ed25519-2020/v1"
  ],
  "id": "did:web:the-agora.dev",
  "verificationMethod": [{
    "id": "did:web:the-agora.dev#key-1",
    "type": "Ed25519VerificationKey2020",
    "controller": "did:web:the-agora.dev",
    "publicKeyMultibase": "z6Mk..."
  }],
  "authentication": ["did:web:the-agora.dev#key-1"],
  "assertionMethod": ["did:web:the-agora.dev#key-1"],
  "service": [...]
}
```

## Tests

- Unit: both without-key and with-key paths covered
- Integration: updated assertion to be flexible on `@context` contents

## Deployment

After merge, set `DID_PUBLIC_KEY_MULTIBASE` in the production .env file. Ed25519 key pair already generated and private key stored in 1Password (`Agora DID Ed25519 Key`).

Public key (multibase): `z6MkpH9ZxHLTPTGcNi98y7KSqbPrbekRAKCPhgJ1LzxNh3rV`