### PR TITLE
fix: pass DID_PUBLIC_KEY_MULTIBASE into api container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       RATE_LIMIT_BACKEND: redis
       REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379/0
       ADMIN_API_TOKEN: ${ADMIN_API_TOKEN:?ADMIN_API_TOKEN is required}
+      DID_PUBLIC_KEY_MULTIBASE: ${DID_PUBLIC_KEY_MULTIBASE:-}
     ports:
       - "8000:8000"
     command: >


### PR DESCRIPTION
docker-compose only passes vars explicitly listed in the `environment:` block — adding to `.env` alone doesn't inject them into the container.

Adds `DID_PUBLIC_KEY_MULTIBASE: ${DID_PUBLIC_KEY_MULTIBASE:-}` to the api service. The `:-` default means it's safe if the var is absent (empty string → falsy in the endpoint handler).

Follows PR #71 which added the setting and endpoint logic.