### PR TITLE
feat: add OATR domain verification endpoint

### DIFF
--- a/agora/main.py
+++ b/agora/main.py
@@ -989,7 +989,9 @@ async def well_known_agent_trust() -> JSONResponse:
     return JSONResponse(
         {
             "issuer_id": "agora",
-            "public_key_fingerprint": "agora-2026-03",
+            # SHA-256 hash of the OATR issuer public key bytes (base64url, no padding).
+            # More rigorous than the KID label — unforgeable without the actual key material.
+            "public_key_fingerprint": "1KmwaGaKNEBRz1XFa5hthwcAgy79NtNUGhPiLRLiQpk",
         }
     )
 

--- a/tests/unit/test_well_known_agent_trust.py
+++ b/tests/unit/test_well_known_agent_trust.py
@@ -16,4 +16,5 @@ async def test_well_known_agent_trust_json() -> None:
 
     payload = response.json()
     assert payload["issuer_id"] == "agora"
-    assert payload["public_key_fingerprint"] == "agora-2026-03"
+    # SHA-256 hash of OATR issuer public key bytes (base64url, no padding)
+    assert payload["public_key_fingerprint"] == "1KmwaGaKNEBRz1XFa5hthwcAgy79NtNUGhPiLRLiQpk"


### PR DESCRIPTION
Adds `/.well-known/agent-trust.json` to support Agora's registration in the [Open Agent Trust Registry](https://github.com/FransDevelopment/open-agent-trust-registry) as a trusted attestation issuer.

## What

OATR uses domain verification (same model as Let's Encrypt) to confirm the registrant controls their domain. Hosting this file at the declared website is step 3 of the registration process.

```json
{
  "issuer_id": "agora",
  "public_key_fingerprint": "agora-2026-03"
}
```

The `public_key_fingerprint` is the KID of Agora's registered Ed25519 key — this binds `the-agora.dev` to the issuer entry in the OATR registry.

## Why

The OATR is the CA trust store for the agent internet — a permissionless registry of trusted attestation issuers (runtimes that can vouch for agents they've verified). Agora's existing verification tiers (ERC-8004, operator, DID) make it a natural fit as an attestation issuer. Peter Vessenez (qntm WG) has been explicitly inviting participation.

Once this endpoint is live and the PR to OATR auto-merges, Agora can issue signed JWT attestations for agents in the registry, which external services can verify against the OATR manifest without calling any central server.

## Test

Unit test covers status code, content-type, and exact payload.