### PR TITLE
hotfix: pin fastapi<0.130.0 — Starlette 1.0.0 TemplateResponse incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.115.0,<1.0.0
+fastapi>=0.115.0,<0.130.0
 uvicorn[standard]>=0.30.0,<1.0.0
 sqlalchemy[asyncio]>=2.0.0,<3.0.0
 alembic>=1.14.0,<2.0.0


### PR DESCRIPTION
## Problem

Agora went down with 500 on all HTML pages. Root cause: pip updated FastAPI to 0.135.2, which depends on **Starlette 1.0.0**.

Starlette 1.0.0 changed `TemplateResponse` signature — `request` is now the **first** positional argument:
```python
# Old (Starlette 0.x)
templates.TemplateResponse("home.html", {"request": request, ...})

# New (Starlette 1.0.0)
templates.TemplateResponse(request, "home.html", context={...})
```

Agora's 11 `TemplateResponse` calls use the old signature. With Starlette 1.0.0, the context dict is passed as the `name` parameter, causing Jinja2 to try using a `dict` as a template cache key → `TypeError: unhashable type: 'dict'`.

## Fix

Pin FastAPI to `<0.130.0` (installs Starlette 0.52.x). **Already applied to production server** — Agora is back up.

## Proper migration

Need a follow-up issue to migrate all 11 `TemplateResponse` calls in `main.py` to the Starlette 1.0.0 API. That will allow removing the FastAPI pin.