### PR TITLE
Add staging deployment workflow and deploy docs

### DIFF
--- a/.github/workflows/deploy-agora.yml
+++ b/.github/workflows/deploy-agora.yml
@@ -57,14 +57,16 @@ jobs:
             "REPO_HTTPS_URL='$REPO_HTTPS_URL' TARGET_REF='$TARGET_REF' DEPLOY_PATH='$EXE_DEPLOY_PATH' bash -se" <<'EOF'
           set -euo pipefail
 
-          if [ ! -d "$DEPLOY_PATH/.git" ]; then
-            git clone --depth=1 "$REPO_HTTPS_URL" "$DEPLOY_PATH"
-          fi
-
+          mkdir -p "$DEPLOY_PATH"
           cd "$DEPLOY_PATH"
           if [ ! -f ".env" ]; then
             echo "Missing $DEPLOY_PATH/.env on VM; deployment stopped." >&2
             exit 1
+          fi
+
+          if [ ! -d ".git" ]; then
+            git init
+            git remote add origin "$REPO_HTTPS_URL"
           fi
 
           git fetch --prune origin "$TARGET_REF"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -111,14 +111,16 @@ jobs:
             "REPO_HTTPS_URL='$REPO_HTTPS_URL' TARGET_REFSPEC='$TARGET_REFSPEC' TARGET_LABEL='$TARGET_LABEL' DEPLOY_PATH='$EXE_DEPLOY_PATH' bash -se" <<'EOF'
           set -euo pipefail
 
-          if [ ! -d "$DEPLOY_PATH/.git" ]; then
-            git clone --depth=1 "$REPO_HTTPS_URL" "$DEPLOY_PATH"
-          fi
-
+          mkdir -p "$DEPLOY_PATH"
           cd "$DEPLOY_PATH"
           if [ ! -f ".env" ]; then
             echo "Missing $DEPLOY_PATH/.env on VM; deployment stopped." >&2
             exit 1
+          fi
+
+          if [ ! -d ".git" ]; then
+            git init
+            git remote add origin "$REPO_HTTPS_URL"
           fi
 
           git fetch --prune origin "$TARGET_REFSPEC"
@@ -128,3 +130,24 @@ jobs:
           docker compose up -d --build --force-recreate --remove-orphans
           docker compose ps
           EOF
+
+      - name: Smoke check staging deployment
+        env:
+          STAGING_BASE_URL: https://staging.the-agora.dev
+        run: |
+          set -euo pipefail
+
+          curl --fail --silent --show-error \
+            --retry 12 --retry-delay 5 --retry-connrefused \
+            --output /dev/null \
+            "$STAGING_BASE_URL/"
+
+          curl --fail --silent --show-error \
+            --retry 12 --retry-delay 5 --retry-connrefused \
+            "$STAGING_BASE_URL/api/v1/health" \
+            | python3 -c 'import json, sys; payload = json.load(sys.stdin); assert payload["status"] == "healthy", payload'
+
+          curl --fail --silent --show-error \
+            --retry 12 --retry-delay 5 --retry-connrefused \
+            "$STAGING_BASE_URL/api/v1/agents" \
+            | python3 -c 'import json, sys; payload = json.load(sys.stdin); assert isinstance(payload.get("agents"), list), payload'

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,117 @@
+# Deploying Agora
+
+This document describes the current production and staging deployment setup for Agora on exe.dev.
+
+## Environments
+
+### Production
+
+- GitHub Actions environment: `production`
+- exe.dev VM: `the-agora`
+- Public URLs:
+  - `https://the-agora.dev`
+  - `https://the-agora.exe.xyz`
+
+### Staging
+
+- GitHub Actions environment: `staging`
+- exe.dev VM: `the-agora-staging`
+- Public URLs:
+  - `https://staging.the-agora.dev`
+  - `https://the-agora-staging.exe.xyz`
+
+## Required GitHub Environment Secrets
+
+Both `production` and `staging` environments use the same secret names:
+
+- `EXE_SSH_DEST`
+- `EXE_DEPLOY_PRIVATE_KEY`
+- `EXE_KNOWN_HOSTS`
+- `EXE_DEPLOY_PATH`
+
+The values differ by environment.
+
+## Production Deploys
+
+Production deploys automatically on push to `main` via:
+
+- [`.github/workflows/deploy-agora.yml`](.github/workflows/deploy-agora.yml)
+
+The workflow:
+
+1. Loads secrets from the `production` GitHub Actions environment.
+2. SSHes to the production exe.dev VM.
+3. Fetches the target ref.
+4. Runs `docker compose up -d --build --force-recreate --remove-orphans`.
+
+## Staging Deploys
+
+Staging deploys run via:
+
+- [`.github/workflows/deploy-staging.yml`](.github/workflows/deploy-staging.yml)
+
+Automatic staging deploys:
+
+- Trigger on pull requests for:
+  - `opened`
+  - `reopened`
+  - `synchronize`
+  - `ready_for_review`
+- Only run automatically when the PR author is one of:
+  - `archedark-ada`
+  - `archedark`
+  - `archedark-gavlan`
+
+Manual staging deploys:
+
+- Use `workflow_dispatch`
+- Provide either:
+  - `ref`, or
+  - `pr_number`
+
+Examples:
+
+```bash
+gh workflow run deploy-staging.yml --ref issue-77-staging-deploy -f ref=issue-77-staging-deploy
+```
+
+```bash
+gh workflow run deploy-staging.yml -f pr_number=123
+```
+
+## Staging Smoke Checks
+
+The staging workflow verifies:
+
+- `GET /` returns `200`
+- `GET /api/v1/health` returns healthy JSON
+- `GET /api/v1/agents` returns valid JSON
+
+These checks run against:
+
+- `https://staging.the-agora.dev`
+
+## Custom Domain Notes
+
+For exe.dev custom domains:
+
+- point `staging.the-agora.dev` to `the-agora-staging.exe.xyz` with a `CNAME`
+- point `the-agora.dev` to the production VM per existing DNS configuration
+- if Cloudflare is involved, use `DNS only` instead of proxied mode
+
+## VM-local Emergency Redeploy
+
+If GitHub Actions is unavailable, you can redeploy directly over SSH:
+
+```bash
+ssh -i ~/.ssh/id_ed25519_agora_gha exedev@the-agora-staging.exe.xyz '
+  set -euo pipefail
+  cd /home/exedev/agora-staging
+  git fetch --prune origin main
+  git checkout -B staging-deploy origin/main
+  docker compose up -d --build --force-recreate --remove-orphans
+  docker compose ps
+'
+```
+
+Production follows the same pattern with the production VM and deploy path.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ For other setup options, see [`docs/QUICKSTART.md`](docs/QUICKSTART.md).
 | Guide | Purpose |
 |-------|---------|
 | [`QUICKSTART.md`](docs/QUICKSTART.md) | Get running locally or in production |
+| [`DEPLOY.md`](DEPLOY.md) | Production and staging deployment workflow |
 | [`FIRST_AGENT_API.md`](docs/FIRST_AGENT_API.md) | Full agent lifecycle walkthrough |
 | [`API_REFERENCE.md`](docs/API_REFERENCE.md) | Endpoint specs and status codes |
 | [`.agents/skills/agora-agent-registry/SKILL.md`](.agents/skills/agora-agent-registry/SKILL.md) | Agent-native workflow for self-registration, updates, discovery, and recovery |

--- a/agora/main.py
+++ b/agora/main.py
@@ -941,9 +941,20 @@ async def skill_markdown() -> PlainTextResponse:
     return PlainTextResponse(_load_skill_markdown(), media_type="text/markdown")
 
 
+def _request_public_base_url(request: Request) -> str:
+    forwarded_host = request.headers.get("x-forwarded-host")
+    if not forwarded_host:
+        return str(request.base_url).rstrip("/")
+
+    forwarded_proto = request.headers.get("x-forwarded-proto", request.url.scheme)
+    proto = forwarded_proto.split(",", maxsplit=1)[0].strip() or request.url.scheme
+    host = forwarded_host.split(",", maxsplit=1)[0].strip()
+    return f"{proto}://{host}".rstrip("/")
+
+
 @app.get("/.well-known/agent.json", tags=["meta"], include_in_schema=False)
 async def well_known_agent_card(request: Request) -> JSONResponse:
-    base_url = str(request.base_url).rstrip("/")
+    base_url = _request_public_base_url(request)
     return JSONResponse(
         {
             "name": "Agent Agora",

--- a/tests/integration/test_a2a_agent_card.py
+++ b/tests/integration/test_a2a_agent_card.py
@@ -21,6 +21,22 @@ async def test_well_known_agent_json_is_available(client) -> None:
     assert payload["contact"]["url"] == "http://testserver/api/v1/agents"
 
 
+async def test_well_known_agent_json_prefers_forwarded_public_url(client) -> None:
+    response = await client.get(
+        "/.well-known/agent.json",
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "staging.the-agora.dev",
+        },
+    )
+
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["url"] == "https://staging.the-agora.dev"
+    assert payload["contact"]["url"] == "https://staging.the-agora.dev/api/v1/agents"
+
+
 async def test_well_known_did_json_is_available(client) -> None:
     response = await client.get("/.well-known/did.json")
 


### PR DESCRIPTION
## Summary
- split production and staging deploy workflows and wire them to GitHub environments
- provision and document the staging deployment path on exe.dev
- add automated staging smoke checks against `https://staging.the-agora.dev`
- make deploy bootstrap work when `.env` exists before `.git`
- fix `/.well-known/agent.json` to prefer forwarded public `https` URL data

## What changed
- added a dedicated staging workflow with trusted-author PR deploys and manual dispatch support
- kept production deploys on `push` to `main`
- added public staging smoke checks for `/`, `/api/v1/health`, and `/api/v1/agents`
- added `DEPLOY.md` and linked it from the README
- added coverage for forwarded host/proto handling in `/.well-known/agent.json`

## Validation
- verified staging is live at `https://staging.the-agora.dev`
- verified public staging endpoints manually:
  - `GET /` -> `200`
  - `GET /api/v1/health` -> healthy JSON
  - `GET /api/v1/agents` -> valid JSON
- parsed both workflow YAML files successfully
- ran targeted tests:
  - `.venv/bin/pytest tests/integration/test_a2a_agent_card.py -k 'well_known_agent_json'`

## Notes
- one unrelated existing integration test is still failing locally:
  - `tests/integration/test_a2a_agent_card.py::test_register_agent_supports_agent_card_url`
  - it returned `400` instead of `201` and does not appear to be caused by this change set

Closes #77
