### PR TITLE
fix: strip Ed25519VerificationKey2020 multicodec prefix in DID key extraction

### DIFF
--- a/agora/commitments.py
+++ b/agora/commitments.py
@@ -116,8 +116,12 @@ def extract_ed25519_public_key_bytes(did_document: dict[str, Any], did: str) -> 
         public_key_multibase = method.get("publicKeyMultibase")
         if isinstance(public_key_multibase, str):
             decoded = _decode_multibase_base58(public_key_multibase)
-            if decoded is not None and len(decoded) == 32:
-                return decoded
+            if decoded is not None:
+                # Strip Ed25519VerificationKey2020 multicodec prefix (0xed 0x01)
+                if len(decoded) == 34 and decoded[:2] == b"\xed\x01":
+                    decoded = decoded[2:]
+                if len(decoded) == 32:
+                    return decoded
 
         public_key_base58 = method.get("publicKeyBase58")
         if isinstance(public_key_base58, str):

--- a/tests/unit/test_commitments.py
+++ b/tests/unit/test_commitments.py
@@ -169,3 +169,67 @@ async def test_verify_commitments_document_requires_verified_did(monkeypatch) ->
 
     assert verified is False
     assert attempts == []
+
+
+async def test_verify_commitments_document_handles_multicodec_prefixed_key(monkeypatch) -> None:
+    """Ed25519VerificationKey2020 publicKeyMultibase values are base58btc-encoded
+    with a 2-byte multicodec prefix (0xed 0x01) prepended to the 32-byte raw key,
+    producing a 34-byte decoded value. extract_ed25519_public_key_bytes must strip
+    the prefix before the len == 32 check or verification silently fails."""
+    did = "did:web:agent.example"
+    commitments_url = "https://agent.example/.well-known/agent-commitments.json"
+
+    signing_key = SigningKey.generate()
+    # Spec-compliant Ed25519VerificationKey2020: prepend 0xed 0x01 multicodec prefix.
+    multicodec_prefixed = b"\xed\x01" + signing_key.verify_key.encode()
+    public_key_multibase = "z" + base58.b58encode(multicodec_prefixed).decode("ascii")
+
+    canonical_payload = {
+        "agent_did": did,
+        "invariants": [{"id": "safe-output-only"}],
+    }
+    canonical_bytes = json.dumps(
+        canonical_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    signature_hex = signing_key.sign(canonical_bytes).signature.hex()
+
+    commitments_payload = {
+        **canonical_payload,
+        "signature": signature_hex,
+    }
+
+    did_document = {
+        "id": did,
+        "verificationMethod": [
+            {
+                "id": f"{did}#owner",
+                "type": "Ed25519VerificationKey2020",
+                "controller": did,
+                "publicKeyMultibase": public_key_multibase,
+            }
+        ],
+    }
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/.well-known/agent-commitments.json":
+            return httpx.Response(200, json=commitments_payload, request=request)
+        if request.url.path == "/.well-known/did.json":
+            return httpx.Response(200, json=did_document, request=request)
+        return httpx.Response(404, request=request)
+
+    monkeypatch.setattr("agora.commitments.assert_url_safe_for_outbound", _safe_target)
+    monkeypatch.setattr("agora.commitments.pin_hostname_resolution", _noop_pin_hostname_resolution)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        verified = await verify_commitments_document(
+            commitments_url=commitments_url,
+            did=did,
+            did_verified=True,
+            allow_private_network_targets=False,
+            client=client,
+        )
+
+    assert verified is True


### PR DESCRIPTION
Fixes #84.

## Problem

`extract_ed25519_public_key_bytes` in `agora/commitments.py` base58btc-decodes `publicKeyMultibase` values but doesn't account for the 2-byte multicodec prefix (`0xed 0x01`) used by spec-compliant `Ed25519VerificationKey2020` keys. The decoded value is 34 bytes; the `len(decoded) == 32` check silently rejects it, so `verify-did` always fails for keys encoded this way.

This is surfaced correctly by the preflight endpoint (`POST /api/v1/agents/preflight`): the DID check returns `fail` for any agent using a spec-compliant key, including the Agora registry's own DID.

## Fix

After base58btc-decoding `publicKeyMultibase`, check if the result is 34 bytes starting with `\xed\x01` and strip those 2 bytes before the length check:

```python
if len(decoded) == 34 and decoded[:2] == b"\xed\x01":
    decoded = decoded[2:]
if len(decoded) == 32:
    return decoded
```

## Test

Added `test_verify_commitments_document_handles_multicodec_prefixed_key` — constructs an `Ed25519VerificationKey2020` key with the spec-compliant multicodec prefix and verifies that `verify_commitments_document` succeeds end-to-end.

The existing tests use raw 32-byte keys without the prefix and continue to pass unchanged.