### PR TITLE
fix: derive did.json id and serviceEndpoint from request host

### DIFF
--- a/agora/main.py
+++ b/agora/main.py
@@ -976,8 +976,10 @@ async def well_known_agent_card(request: Request) -> JSONResponse:
 
 
 @app.get("/.well-known/did.json", tags=["meta"], include_in_schema=False)
-async def well_known_did_document() -> JSONResponse:
-    did = "did:web:the-agora.dev"
+async def well_known_did_document(request: Request) -> JSONResponse:
+    base_url = _request_public_base_url(request)
+    host = base_url.removeprefix("https://").removeprefix("http://")
+    did = f"did:web:{host}"
     contexts: list[str] = ["https://www.w3.org/ns/did/v1"]
     document: dict[str, object] = {
         "id": did,
@@ -985,7 +987,7 @@ async def well_known_did_document() -> JSONResponse:
             {
                 "id": f"{did}#registry",
                 "type": "AgentRegistry",
-                "serviceEndpoint": "https://the-agora.dev",
+                "serviceEndpoint": base_url,
             }
         ],
     }

--- a/tests/unit/test_well_known_did_document.py
+++ b/tests/unit/test_well_known_did_document.py
@@ -9,7 +9,10 @@ async def test_well_known_did_json_without_key() -> None:
     """When no public key is configured, serve the base DID document."""
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
-        response = await client.get("/.well-known/did.json")
+        response = await client.get(
+            "/.well-known/did.json",
+            headers={"x-forwarded-host": "the-agora.dev", "x-forwarded-proto": "https"},
+        )
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/did+json")
@@ -42,7 +45,10 @@ async def test_well_known_did_json_with_verification_method(monkeypatch) -> None
     try:
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
-            response = await client.get("/.well-known/did.json")
+            response = await client.get(
+                "/.well-known/did.json",
+                headers={"x-forwarded-host": "the-agora.dev", "x-forwarded-proto": "https"},
+            )
 
         assert response.status_code == 200
         payload = response.json()
@@ -69,3 +75,24 @@ async def test_well_known_did_json_with_verification_method(monkeypatch) -> None
         # Restore clean settings cache
         monkeypatch.delenv("DID_PUBLIC_KEY_MULTIBASE", raising=False)
         get_settings.cache_clear()
+
+
+async def test_well_known_did_json_uses_forwarded_host_for_staging() -> None:
+    """did.json id and serviceEndpoint must reflect the actual request host so that
+    staging.the-agora.dev returns did:web:staging.the-agora.dev, not the production DID."""
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get(
+            "/.well-known/did.json",
+            headers={
+                "x-forwarded-host": "staging.the-agora.dev",
+                "x-forwarded-proto": "https",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["id"] == "did:web:staging.the-agora.dev"
+    assert payload["service"][0]["id"] == "did:web:staging.the-agora.dev#registry"
+    assert payload["service"][0]["serviceEndpoint"] == "https://staging.the-agora.dev"


### PR DESCRIPTION
Fixes the hardcoded `the-agora.dev` in `/.well-known/did.json`.

## Problem

`well_known_did_document` had the host hardcoded: `did = "did:web:the-agora.dev"`. This means staging returns `did:web:the-agora.dev` instead of `did:web:staging.the-agora.dev`, breaking DID verification for any agent registered via staging.

## Fix

Use the existing `_request_public_base_url()` helper — same one that `/.well-known/agent.json` already uses — to derive the host from `X-Forwarded-Host` (with fallback to the actual request host).

## Tests

- Updated existing tests to pass `x-forwarded-host: the-agora.dev` (matching how nginx proxies production requests)
- Added `test_well_known_did_json_uses_forwarded_host_for_staging`: sends `x-forwarded-host: staging.the-agora.dev` and asserts the response `id` and `serviceEndpoint` reflect the staging host